### PR TITLE
销毁线程时，如果有锁wait就不会销毁线程，导致线程数一直增加最终导致服务死掉

### DIFF
--- a/src/main/java/cn/org/hentai/jtt1078/subscriber/Subscriber.java
+++ b/src/main/java/cn/org/hentai/jtt1078/subscriber/Subscriber.java
@@ -72,6 +72,10 @@ public abstract class Subscriber extends Thread
             }
             catch(Exception ex)
             {
+                //销毁线程时，如果有锁wait就不会销毁线程，抛出InterruptedException异常
+                if(ex instanceof InterruptedException){
+                    break loop;
+                }
                 logger.error("send failed", ex);
             }
         }


### PR DESCRIPTION
压测时线程数一直增长，最终OOM，发现调用interrupt销毁线程时，如果线程内有wait、sleep等方法，就会销毁失败，直接抛出InterruptedException异常。在捕获到该异常时，应退出该线程